### PR TITLE
Feature / Add Login and Create Account Screen UI

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
             implementation(libs.multiplatform.settings)
             implementation(libs.kermit)
             implementation(libs.androidx.room.runtime)
+            implementation(libs.androidx.navigation.compose)
         }
 
         iosMain.dependencies {

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -8,4 +8,9 @@
     <string name="shorten_your_links">Shorten your links\nwith ease</string>
     <string name="simplify_long_urls">Simplify long URLs, track engagement on link visits, customize short links, password protect your links and more.</string>
     <string name="features_only_available_with_an_account">* some features only available with an account</string>
+    <string name="first_name">First Name</string>
+    <string name="last_name">Last Name</string>
+    <string name="email">Email</string>
+    <string name="password">Password</string>
+    <string name="confirm_password">Confirm Password</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="forgot_password">Forgot Password?</string>
     <string name="first_name">First Name</string>
     <string name="last_name">Last Name</string>
-    <string name="password">Password</string>
     <string name="confirm_password">Confirm Password</string>
+    <string name="valid_first_name">Enter your first name</string>
+    <string name="valid_last_name">Enter your last name</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,11 +1,17 @@
 <resources>
     <string name="app_name">Snippy</string>
     <string name="shorten">Shorten</string>
-    <string name="login">Login</string>
-    <string name="create_account">Create Account</string>
     <string name="url_hint">https://example.com</string>
     <string name="privacy_policy">\u00a9 2025 All Rights Reserved.</string>
     <string name="shorten_your_links">Shorten your links\nwith ease</string>
     <string name="simplify_long_urls">Simplify long URLs, track engagement on link visits, customize short links, password protect your links and more.</string>
     <string name="features_only_available_with_an_account">* some features only available with an account</string>
+
+    <!--> Authentication -->
+    <string name="login">Login</string>
+    <string name="create_account">Create Account</string>
+    <string name="email_address">Email Address</string>
+    <string name="password">Password</string>
+    <string name="forgot_password">Forgot Password?</string>
+
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/App.kt
@@ -2,7 +2,6 @@ package com.theseuntaylor.snippy
 
 import androidx.compose.runtime.Composable
 import com.theseuntaylor.snippy.ui.destinations.home.HomeScreen
-import com.theseuntaylor.snippy.ui.destinations.signup.SignupScreen
 import com.theseuntaylor.snippy.ui.theme.SnippyTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -10,6 +9,6 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     SnippyTheme {
-        SignupScreen()
+        HomeScreen()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/App.kt
@@ -2,6 +2,7 @@ package com.theseuntaylor.snippy
 
 import androidx.compose.runtime.Composable
 import com.theseuntaylor.snippy.ui.destinations.home.HomeScreen
+import com.theseuntaylor.snippy.ui.destinations.signup.SignupScreen
 import com.theseuntaylor.snippy.ui.theme.SnippyTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -9,6 +10,6 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     SnippyTheme {
-        HomeScreen()
+        SignupScreen()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/ComposableParam.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/ComposableParam.kt
@@ -1,0 +1,5 @@
+package com.theseuntaylor.snippy.ui.components
+
+import androidx.compose.runtime.Composable
+
+typealias ComposableParam = @Composable () -> Unit

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/SnippyButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/SnippyButton.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 fun SnippyButton(
     onClick: () -> Unit,
     textContent: String,
+    enabled: Boolean = true,
     modifier: Modifier = Modifier,
     containerColor: Color = MaterialTheme.colorScheme.secondary,
     textPadding: Dp = 6.dp,
@@ -24,6 +25,7 @@ fun SnippyButton(
         onClick = onClick,
         modifier = modifier,
         shape = RoundedCornerShape(6.dp),
+        enabled = enabled,
         content = {
             Text(
                 text = textContent,

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/SnippyEndTextButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/SnippyEndTextButton.kt
@@ -1,0 +1,26 @@
+package com.theseuntaylor.snippy.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+internal fun SnippyEndTextButton(
+    onClick: () -> Unit,
+    textContent: String,
+    style: TextStyle = LocalTextStyle.current,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
+        SnippyFillSpacer()
+        Text(
+            text = textContent,
+            style = style,
+            modifier = Modifier.clickable(onClick = onClick),
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/SnippyLogo.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/SnippyLogo.kt
@@ -1,0 +1,36 @@
+package com.theseuntaylor.snippy.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import snippy.composeapp.generated.resources.Res
+import snippy.composeapp.generated.resources.app_name
+import snippy.composeapp.generated.resources.compose_multiplatform
+
+@Composable
+internal fun SnippyLogo(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            painter = painterResource(Res.drawable.compose_multiplatform),
+            contentDescription = "App Icon",
+            modifier = Modifier.size(size = 24.dp),
+        )
+        Text(
+            text = stringResource(resource = Res.string.app_name),
+            style = MaterialTheme.typography.titleMedium,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/Spacer.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/components/Spacer.kt
@@ -1,5 +1,7 @@
 package com.theseuntaylor.snippy.ui.components
 
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
@@ -19,4 +21,14 @@ fun SnippyHorizontalSpacer(
     width: Dp,
 ) {
     Spacer(modifier = Modifier.width(width = width))
+}
+
+@Composable
+fun RowScope.SnippyFillSpacer() {
+    Spacer(modifier = Modifier.weight(weight = 1f))
+}
+
+@Composable
+fun ColumnScope.SnippyFillSpacer() {
+    Spacer(modifier = Modifier.weight(weight = 1f))
 }

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/login/LoginScreen.kt
@@ -1,0 +1,134 @@
+package com.theseuntaylor.snippy.ui.destinations.login
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.theseuntaylor.snippy.ui.components.SnippyButton
+import com.theseuntaylor.snippy.ui.components.SnippyEndTextButton
+import com.theseuntaylor.snippy.ui.components.SnippyFillSpacer
+import com.theseuntaylor.snippy.ui.components.SnippyLogo
+import com.theseuntaylor.snippy.ui.components.SnippyVerticalSpacer
+import com.theseuntaylor.snippy.ui.destinations.shared.PasswordTextInputField
+import com.theseuntaylor.snippy.ui.destinations.shared.TextInput
+import com.theseuntaylor.snippy.ui.destinations.shared.TextInputField
+import com.theseuntaylor.snippy.ui.model.InputFieldError
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import org.jetbrains.compose.resources.stringResource
+import snippy.composeapp.generated.resources.Res
+import snippy.composeapp.generated.resources.email_address
+import snippy.composeapp.generated.resources.forgot_password
+import snippy.composeapp.generated.resources.login
+import snippy.composeapp.generated.resources.password
+
+@OptIn(FlowPreview::class)
+@Composable
+internal fun LoginScreen(modifier: Modifier = Modifier) {
+    var emailInput by remember { mutableStateOf("") }
+    val passwordState = rememberTextFieldState()
+    var passwordError by remember { mutableStateOf(InputFieldError.Initial) }
+
+    val enable by remember {
+        derivedStateOf {
+            emailInput.isNotBlank() && passwordState.text.length >= 8
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { passwordState.text }
+            .drop(count = 2)
+            .debounce(timeoutMillis = 500)
+            .collect {
+                passwordError = if (it.length < 8) {
+                    InputFieldError(
+                        shouldShowError = true,
+                        message = "Enter at least 8 characters",
+                    )
+                } else {
+                    InputFieldError.Initial
+                }
+            }
+    }
+
+    Column(
+        modifier = modifier.padding(
+            horizontal = 20.dp,
+            vertical = 40.dp,
+        ).fillMaxSize(),
+    ) {
+        LoginContent(
+            emailInput = emailInput,
+            passwordState = passwordState,
+            passwordError = passwordError,
+            enable = enable,
+            onEmailChange = { emailInput = it },
+        )
+
+    }
+}
+
+@Composable
+private fun ColumnScope.LoginContent(
+    emailInput: String,
+    passwordState: TextFieldState,
+    passwordError: InputFieldError,
+    enable: Boolean,
+    onEmailChange: (String) -> Unit,
+) {
+    SnippyLogo()
+
+    SnippyVerticalSpacer(height = 38.dp)
+
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.email_address),
+        showErrorMessage = true,
+        errorMessage = "Enter a valid email address",
+        inputField = {
+            TextInputField(
+                value = emailInput,
+                sectionTitle = stringResource(resource = Res.string.email_address),
+                onValueChange = onEmailChange,
+            )
+        },
+    )
+
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.password),
+        showErrorMessage = passwordError.shouldShowError,
+        errorMessage = "Enter at least 8 characters",
+        modifier = Modifier.padding(vertical = 20.dp),
+        inputField = { PasswordTextInputField(passwordState = passwordState) },
+    )
+
+    SnippyEndTextButton(
+        onClick = { /*TODO*/ },
+        textContent = stringResource(resource = Res.string.forgot_password),
+        style = MaterialTheme.typography.bodySmall,
+    )
+
+    SnippyFillSpacer()
+
+    SnippyButton(
+        onClick = { /*TODO*/ },
+        modifier = Modifier.fillMaxWidth(),
+        enabled = enable,
+        textContent = stringResource(resource = Res.string.login),
+        containerColor = MaterialTheme.colorScheme.secondary,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/login/LoginScreen.kt
@@ -44,7 +44,7 @@ internal fun LoginScreen(modifier: Modifier = Modifier) {
     val passwordState = rememberTextFieldState()
     var passwordError by remember { mutableStateOf(InputFieldError.Initial) }
 
-    val enable by remember {
+    val isSubmitEnabled by remember {
         derivedStateOf {
             emailInput.isNotBlank() && passwordState.text.length >= 8
         }
@@ -76,7 +76,7 @@ internal fun LoginScreen(modifier: Modifier = Modifier) {
             emailInput = emailInput,
             passwordState = passwordState,
             passwordError = passwordError,
-            enable = enable,
+            isSubmitEnabled = isSubmitEnabled,
             onEmailChange = { emailInput = it },
         )
 
@@ -88,7 +88,7 @@ private fun ColumnScope.LoginContent(
     emailInput: String,
     passwordState: TextFieldState,
     passwordError: InputFieldError,
-    enable: Boolean,
+    isSubmitEnabled: Boolean,
     onEmailChange: (String) -> Unit,
 ) {
     SnippyLogo()
@@ -127,7 +127,7 @@ private fun ColumnScope.LoginContent(
     SnippyButton(
         onClick = { /*TODO*/ },
         modifier = Modifier.fillMaxWidth(),
-        enabled = enable,
+        enabled = isSubmitEnabled,
         textContent = stringResource(resource = Res.string.login),
         containerColor = MaterialTheme.colorScheme.secondary,
     )

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/shared/PasswordTextInputField.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/shared/PasswordTextInputField.kt
@@ -1,0 +1,77 @@
+package com.theseuntaylor.snippy.ui.destinations.shared
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicSecureTextField
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.TextObfuscationMode
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.theseuntaylor.snippy.ui.icons.Visibility
+import com.theseuntaylor.snippy.ui.icons.VisibilityOff
+
+@Composable
+internal fun PasswordTextInputField(
+    passwordState: TextFieldState,
+) {
+    var showPassword by remember { mutableStateOf(false) }
+    BasicSecureTextField(
+        state = passwordState,
+        textStyle = MaterialTheme.typography.bodyMedium,
+        textObfuscationMode =
+            if (showPassword) {
+                TextObfuscationMode.Visible
+            } else {
+                TextObfuscationMode.RevealLastTyped
+            },
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = Color.LightGray,
+                shape = RoundedCornerShape(size = 22.dp),
+            ),
+        decorator = { innerTextField ->
+            Box(
+                modifier = Modifier.padding(vertical = 6.dp)
+                    .fillMaxWidth()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .padding(horizontal = 16.dp)
+                ) {
+                    innerTextField()
+                }
+                Icon(
+                    imageVector =
+                        if (showPassword) {
+                            Icons.Filled.Visibility
+                        } else {
+                            Icons.Filled.VisibilityOff
+                        },
+                    contentDescription = "Toggle password visibility",
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .requiredSize(size = 48.dp).padding(all = 16.dp)
+                        .clickable { showPassword = !showPassword }
+                )
+            }
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/shared/TextInput.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/shared/TextInput.kt
@@ -1,0 +1,97 @@
+package com.theseuntaylor.snippy.ui.destinations.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.theseuntaylor.snippy.ui.components.ComposableParam
+import com.theseuntaylor.snippy.ui.components.SnippyFillSpacer
+import com.theseuntaylor.snippy.ui.components.SnippyVerticalSpacer
+import com.theseuntaylor.snippy.ui.theme.SnippyTheme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+internal fun TextInput(
+    sectionTitle: String,
+    showErrorMessage: Boolean,
+    modifier: Modifier = Modifier,
+    errorMessage: String? = null,
+    inputField: ComposableParam,
+) {
+    Column(modifier = modifier) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = sectionTitle,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            SnippyFillSpacer()
+
+            if (showErrorMessage && errorMessage != null) {
+                Text(
+                    text = errorMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+
+        SnippyVerticalSpacer(height = 4.dp)
+
+        inputField()
+    }
+}
+
+@Composable
+internal fun TextInputField(
+    value: String,
+    sectionTitle: String,
+    onValueChange: (String) -> Unit,
+    trailingIcon: ComposableParam? = null,
+) {
+    OutlinedTextField(
+        value = value,
+        shape = RoundedCornerShape(size = 22.dp),
+        onValueChange = onValueChange,
+        placeholder = {
+            Text(
+                text = sectionTitle,
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        trailingIcon = trailingIcon,
+        modifier = Modifier
+            .fillMaxWidth()
+    )
+}
+
+@Preview
+@Composable
+private fun TextInputPreview() {
+    SnippyTheme {
+        TextInput(
+            sectionTitle = "Email Address",
+            showErrorMessage = true,
+            errorMessage = "Enter a valid email address",
+            inputField = {
+                TextInputField(
+                    value = "",
+                    sectionTitle = "Email Address",
+                    onValueChange = {},
+                )
+            }
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
@@ -55,7 +55,7 @@ fun SignupScreen(modifier: Modifier = Modifier) {
     }
 
     Column(
-        modifier = Modifier.padding(
+        modifier = modifier.padding(
             horizontal = 20.dp,
             vertical = 40.dp,
         ).fillMaxSize(),

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,7 +43,16 @@ fun SignupScreen(modifier: Modifier = Modifier) {
     val passwordState = rememberTextFieldState()
     val confirmPasswordState = rememberTextFieldState()
     val passwordError by remember { mutableStateOf(InputFieldError.Initial) }
-    val isButtonEnabled by remember { mutableStateOf(false) }
+
+    val isButtonEnabled by remember {
+        derivedStateOf {
+            firstNameInput.isNotBlank()
+                    && lastNameInput.isNotBlank()
+                    && emailInput.isNotBlank()
+                    && passwordState.text.length >= 8
+                    && confirmPasswordState.text.length >= 8
+        }
+    }
 
     Column(
         modifier = Modifier.padding(
@@ -68,7 +78,7 @@ fun SignupScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun ColumnScope.SignupScreenContent(
+private fun ColumnScope.SignupScreenContent(
     firstNameInput: String,
     lastNameInput: String,
     emailInput: String,
@@ -131,6 +141,7 @@ fun ColumnScope.SignupScreenContent(
         modifier = Modifier.padding(vertical = 20.dp),
         inputField = { PasswordTextInputField(passwordState = passwordState) },
     )
+
     TextInput(
         sectionTitle = stringResource(resource = Res.string.password),
         showErrorMessage = passwordError.shouldShowError,

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
@@ -1,0 +1,201 @@
+package com.theseuntaylor.snippy.ui.destinations.signup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.theseuntaylor.snippy.ui.components.SnippyButton
+import org.jetbrains.compose.resources.stringResource
+import snippy.composeapp.generated.resources.Res
+import snippy.composeapp.generated.resources.confirm_password
+import snippy.composeapp.generated.resources.create_account
+import snippy.composeapp.generated.resources.email
+import snippy.composeapp.generated.resources.first_name
+import snippy.composeapp.generated.resources.last_name
+import snippy.composeapp.generated.resources.password
+import snippy.composeapp.generated.resources.url_hint
+
+@Composable
+fun SignupScreen(
+    modifier: Modifier = Modifier,
+) {
+
+    var firstNameInput by remember { mutableStateOf("") }
+    var lastNameInput by remember { mutableStateOf("") }
+    var emailInput by remember { mutableStateOf("") }
+    var passwordInput by remember { mutableStateOf("") }
+    var confirmPasswordInput by remember { mutableStateOf("") }
+
+    var passwordVisibility by remember { mutableStateOf(false) }
+    var confirmPasswordVisibility by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier.padding(
+            horizontal = 20.dp,
+            vertical = 40.dp,
+        ).fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Text(
+            stringResource(Res.string.create_account),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Column {
+            Text("First Name")
+            OutlinedTextField(
+                value = firstNameInput,
+                onValueChange = { firstNameInput = it },
+                placeholder = {
+                    Text(
+                        text = stringResource(resource = Res.string.first_name),
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next
+                )
+            )
+        }
+
+        Column {
+            Text("Last Name")
+            OutlinedTextField(
+                value = lastNameInput,
+                onValueChange = { lastNameInput = it },
+                placeholder = {
+                    Text(
+                        text = stringResource(resource = Res.string.last_name),
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next
+                )
+            )
+        }
+
+        Column {
+            Text("Email Address")
+            OutlinedTextField(
+                value = emailInput,
+                onValueChange = { emailInput = it },
+                placeholder = {
+                    Text(
+                        text = stringResource(resource = Res.string.email),
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next
+                )
+            )
+        }
+
+        Column {
+            Text("Password")
+            OutlinedTextField(
+                value = passwordInput,
+                onValueChange = { passwordInput = it },
+                visualTransformation = if (passwordVisibility) VisualTransformation.None else PasswordVisualTransformation(),
+                placeholder = {
+                    Text(
+                        text = stringResource(resource = Res.string.password),
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                trailingIcon = {
+                    IconButton(onClick = {
+                        passwordVisibility = !passwordVisibility
+                    }) {
+                        if (passwordVisibility) {
+                            Icon(
+                                Icons.Filled.Warning,
+                                contentDescription = "Toggle password visibility"
+                            )
+                        } else {
+                            Icon(
+                                Icons.Filled.Warning,
+                                contentDescription = "Toggle password visibility"
+                            )
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Next
+                )
+            )
+        }
+
+        Column {
+            Text("Confirm Password")
+            OutlinedTextField(
+                value = confirmPasswordInput,
+                onValueChange = { confirmPasswordInput = it },
+                visualTransformation = if (confirmPasswordVisibility) VisualTransformation.None else PasswordVisualTransformation(),
+                placeholder = {
+                    Text(
+                        text = stringResource(resource = Res.string.confirm_password),
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                trailingIcon = {
+                    IconButton(onClick = {
+                        confirmPasswordVisibility = !confirmPasswordVisibility
+                    }) {
+                        if (passwordVisibility) {
+                            Icon(
+                                Icons.Outlined.Warning,
+                                contentDescription = "Toggle password visibility"
+                            )
+                        } else {
+                            Icon(
+                                Icons.Filled.Warning,
+                                contentDescription = "Toggle password visibility"
+                            )
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Done
+                )
+            )
+        }
+        SnippyButton(
+            onClick = { /*TODO*/ },
+            modifier = Modifier.fillMaxWidth(),
+            textContent = stringResource(resource = Res.string.create_account),
+            containerColor = MaterialTheme.colorScheme.primary,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
@@ -20,12 +20,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.theseuntaylor.snippy.ui.components.SnippyButton
+import com.theseuntaylor.snippy.ui.components.SnippyFillSpacer
 import com.theseuntaylor.snippy.ui.destinations.shared.PasswordTextInputField
 import com.theseuntaylor.snippy.ui.destinations.shared.TextInput
 import com.theseuntaylor.snippy.ui.model.InputFieldError
 import com.theseuntaylor.snippy.ui.destinations.shared.TextInputField
 import org.jetbrains.compose.resources.stringResource
 import snippy.composeapp.generated.resources.Res
+import snippy.composeapp.generated.resources.confirm_password
 import snippy.composeapp.generated.resources.create_account
 import snippy.composeapp.generated.resources.email_address
 import snippy.composeapp.generated.resources.first_name
@@ -134,21 +136,22 @@ private fun ColumnScope.SignupScreenContent(
             )
         },
     )
-    TextInput(
-        sectionTitle = stringResource(resource = Res.string.password),
-        showErrorMessage = passwordError.shouldShowError,
-        errorMessage = "Enter at least 8 characters",
-        modifier = Modifier.padding(vertical = 20.dp),
-        inputField = { PasswordTextInputField(passwordState = passwordState) },
-    )
 
     TextInput(
         sectionTitle = stringResource(resource = Res.string.password),
         showErrorMessage = passwordError.shouldShowError,
         errorMessage = "Enter at least 8 characters",
-        modifier = Modifier.padding(vertical = 20.dp),
+        inputField = { PasswordTextInputField(passwordState = passwordState) },
+    )
+
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.confirm_password),
+        showErrorMessage = passwordError.shouldShowError,
+        errorMessage = "Enter at least 8 characters",
         inputField = { PasswordTextInputField(passwordState = confirmPasswordState) },
     )
+
+    SnippyFillSpacer()
 
     SnippyButton(
         onClick = { /*TODO*/ },

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/destinations/signup/SignupScreen.kt
@@ -2,17 +2,13 @@ package com.theseuntaylor.snippy.ui.destinations.signup
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material.icons.outlined.Warning
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,181 +17,133 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.theseuntaylor.snippy.ui.components.SnippyButton
+import com.theseuntaylor.snippy.ui.destinations.shared.PasswordTextInputField
+import com.theseuntaylor.snippy.ui.destinations.shared.TextInput
+import com.theseuntaylor.snippy.ui.model.InputFieldError
+import com.theseuntaylor.snippy.ui.destinations.shared.TextInputField
 import org.jetbrains.compose.resources.stringResource
 import snippy.composeapp.generated.resources.Res
-import snippy.composeapp.generated.resources.confirm_password
 import snippy.composeapp.generated.resources.create_account
-import snippy.composeapp.generated.resources.email
+import snippy.composeapp.generated.resources.email_address
 import snippy.composeapp.generated.resources.first_name
 import snippy.composeapp.generated.resources.last_name
 import snippy.composeapp.generated.resources.password
-import snippy.composeapp.generated.resources.url_hint
+import snippy.composeapp.generated.resources.valid_first_name
+import snippy.composeapp.generated.resources.valid_last_name
+
 
 @Composable
-fun SignupScreen(
-    modifier: Modifier = Modifier,
-) {
-
+fun SignupScreen(modifier: Modifier = Modifier) {
     var firstNameInput by remember { mutableStateOf("") }
     var lastNameInput by remember { mutableStateOf("") }
     var emailInput by remember { mutableStateOf("") }
-    var passwordInput by remember { mutableStateOf("") }
-    var confirmPasswordInput by remember { mutableStateOf("") }
-
-    var passwordVisibility by remember { mutableStateOf(false) }
-    var confirmPasswordVisibility by remember { mutableStateOf(false) }
+    val passwordState = rememberTextFieldState()
+    val confirmPasswordState = rememberTextFieldState()
+    val passwordError by remember { mutableStateOf(InputFieldError.Initial) }
+    val isButtonEnabled by remember { mutableStateOf(false) }
 
     Column(
-        modifier = modifier.padding(
+        modifier = Modifier.padding(
             horizontal = 20.dp,
             vertical = 40.dp,
         ).fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        Text(
-            stringResource(Res.string.create_account),
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
-        )
-
-        Column {
-            Text("First Name")
-            OutlinedTextField(
-                value = firstNameInput,
-                onValueChange = { firstNameInput = it },
-                placeholder = {
-                    Text(
-                        text = stringResource(resource = Res.string.first_name),
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(
-                    imeAction = ImeAction.Next
-                )
-            )
-        }
-
-        Column {
-            Text("Last Name")
-            OutlinedTextField(
-                value = lastNameInput,
-                onValueChange = { lastNameInput = it },
-                placeholder = {
-                    Text(
-                        text = stringResource(resource = Res.string.last_name),
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(
-                    imeAction = ImeAction.Next
-                )
-            )
-        }
-
-        Column {
-            Text("Email Address")
-            OutlinedTextField(
-                value = emailInput,
-                onValueChange = { emailInput = it },
-                placeholder = {
-                    Text(
-                        text = stringResource(resource = Res.string.email),
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(
-                    imeAction = ImeAction.Next
-                )
-            )
-        }
-
-        Column {
-            Text("Password")
-            OutlinedTextField(
-                value = passwordInput,
-                onValueChange = { passwordInput = it },
-                visualTransformation = if (passwordVisibility) VisualTransformation.None else PasswordVisualTransformation(),
-                placeholder = {
-                    Text(
-                        text = stringResource(resource = Res.string.password),
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                trailingIcon = {
-                    IconButton(onClick = {
-                        passwordVisibility = !passwordVisibility
-                    }) {
-                        if (passwordVisibility) {
-                            Icon(
-                                Icons.Filled.Warning,
-                                contentDescription = "Toggle password visibility"
-                            )
-                        } else {
-                            Icon(
-                                Icons.Filled.Warning,
-                                contentDescription = "Toggle password visibility"
-                            )
-                        }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password,
-                    imeAction = ImeAction.Next
-                )
-            )
-        }
-
-        Column {
-            Text("Confirm Password")
-            OutlinedTextField(
-                value = confirmPasswordInput,
-                onValueChange = { confirmPasswordInput = it },
-                visualTransformation = if (confirmPasswordVisibility) VisualTransformation.None else PasswordVisualTransformation(),
-                placeholder = {
-                    Text(
-                        text = stringResource(resource = Res.string.confirm_password),
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                trailingIcon = {
-                    IconButton(onClick = {
-                        confirmPasswordVisibility = !confirmPasswordVisibility
-                    }) {
-                        if (passwordVisibility) {
-                            Icon(
-                                Icons.Outlined.Warning,
-                                contentDescription = "Toggle password visibility"
-                            )
-                        } else {
-                            Icon(
-                                Icons.Filled.Warning,
-                                contentDescription = "Toggle password visibility"
-                            )
-                        }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password,
-                    imeAction = ImeAction.Done
-                )
-            )
-        }
-        SnippyButton(
-            onClick = { /*TODO*/ },
-            modifier = Modifier.fillMaxWidth(),
-            textContent = stringResource(resource = Res.string.create_account),
-            containerColor = MaterialTheme.colorScheme.primary,
+        SignupScreenContent(
+            firstNameInput = firstNameInput,
+            lastNameInput = lastNameInput,
+            emailInput = emailInput,
+            passwordState = passwordState,
+            confirmPasswordState = confirmPasswordState,
+            passwordError = passwordError,
+            onEmailChange = { emailInput = it },
+            onFirstNameChange = { firstNameInput = it },
+            onLastNameChange = { lastNameInput = it },
+            isButtonEnabled = isButtonEnabled
         )
     }
+
+}
+
+@Composable
+fun ColumnScope.SignupScreenContent(
+    firstNameInput: String,
+    lastNameInput: String,
+    emailInput: String,
+    passwordState: TextFieldState,
+    confirmPasswordState: TextFieldState,
+    passwordError: InputFieldError,
+    isButtonEnabled: Boolean,
+    onEmailChange: (String) -> Unit,
+    onFirstNameChange: (String) -> Unit,
+    onLastNameChange: (String) -> Unit,
+) {
+
+    Text(
+        stringResource(Res.string.create_account),
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.Bold,
+    )
+
+    // could mod this to have ime actions for keyboard.
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.first_name),
+        showErrorMessage = true,
+        errorMessage = stringResource(Res.string.valid_first_name),
+        inputField = {
+            TextInputField(
+                value = firstNameInput,
+                sectionTitle = stringResource(Res.string.first_name),
+                onValueChange = onFirstNameChange,
+            )
+        })
+
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.last_name),
+        showErrorMessage = true,
+        errorMessage = stringResource(Res.string.valid_last_name),
+        inputField = {
+            TextInputField(
+                value = lastNameInput,
+                sectionTitle = stringResource(Res.string.last_name),
+                onValueChange = onLastNameChange,
+            )
+        })
+
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.email_address),
+        showErrorMessage = true,
+        errorMessage = "Enter a valid email address",
+        inputField = {
+            TextInputField(
+                value = emailInput,
+                sectionTitle = stringResource(resource = Res.string.email_address),
+                onValueChange = onEmailChange,
+            )
+        },
+    )
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.password),
+        showErrorMessage = passwordError.shouldShowError,
+        errorMessage = "Enter at least 8 characters",
+        modifier = Modifier.padding(vertical = 20.dp),
+        inputField = { PasswordTextInputField(passwordState = passwordState) },
+    )
+    TextInput(
+        sectionTitle = stringResource(resource = Res.string.password),
+        showErrorMessage = passwordError.shouldShowError,
+        errorMessage = "Enter at least 8 characters",
+        modifier = Modifier.padding(vertical = 20.dp),
+        inputField = { PasswordTextInputField(passwordState = confirmPasswordState) },
+    )
+
+    SnippyButton(
+        onClick = { /*TODO*/ },
+        modifier = Modifier.fillMaxWidth(),
+        enabled = isButtonEnabled,
+        textContent = stringResource(resource = Res.string.create_account),
+        containerColor = MaterialTheme.colorScheme.primary,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/icons/VisibilityIcons.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/icons/VisibilityIcons.kt
@@ -1,0 +1,102 @@
+package com.theseuntaylor.snippy.ui.icons
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * We copy the implementation of Visibility and VisibilityOff icons to showcase them in the password
+ * text field by avoiding addition of material-icons-extended library as a dependency to the project.
+ * It is a large dependency and it might lead to increase the build time.
+ * This was gotten from [Android Platform Sample](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material/material/samples/src/main/java/androidx/compose/material/samples/TextFieldSamples.kt;l=189?q=compose%20sample%20text%20input)
+ */
+internal val Icons.Filled.Visibility: ImageVector
+    get() {
+        if (_visibility != null) {
+            return _visibility!!
+        }
+        _visibility =
+            materialIcon(name = "Filled.Visibility") {
+                materialPath {
+                    moveTo(12.0f, 4.5f)
+                    curveTo(7.0f, 4.5f, 2.73f, 7.61f, 1.0f, 12.0f)
+                    curveToRelative(1.73f, 4.39f, 6.0f, 7.5f, 11.0f, 7.5f)
+                    reflectiveCurveToRelative(9.27f, -3.11f, 11.0f, -7.5f)
+                    curveToRelative(-1.73f, -4.39f, -6.0f, -7.5f, -11.0f, -7.5f)
+                    close()
+                    moveTo(12.0f, 17.0f)
+                    curveToRelative(-2.76f, 0.0f, -5.0f, -2.24f, -5.0f, -5.0f)
+                    reflectiveCurveToRelative(2.24f, -5.0f, 5.0f, -5.0f)
+                    reflectiveCurveToRelative(5.0f, 2.24f, 5.0f, 5.0f)
+                    reflectiveCurveToRelative(-2.24f, 5.0f, -5.0f, 5.0f)
+                    close()
+                    moveTo(12.0f, 9.0f)
+                    curveToRelative(-1.66f, 0.0f, -3.0f, 1.34f, -3.0f, 3.0f)
+                    reflectiveCurveToRelative(1.34f, 3.0f, 3.0f, 3.0f)
+                    reflectiveCurveToRelative(3.0f, -1.34f, 3.0f, -3.0f)
+                    reflectiveCurveToRelative(-1.34f, -3.0f, -3.0f, -3.0f)
+                    close()
+                }
+            }
+        return _visibility!!
+    }
+private var _visibility: ImageVector? = null
+
+/**
+ * We copy the implementation of Visibility and VisibilityOff icons to showcase them in the password
+ * text field by avoiding addition of material-icons-extended library as a dependency to the project.
+ * It is a large dependency and it might lead to increase the build time.
+ * This was gotten from [Android Platform Sample](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material/material/samples/src/main/java/androidx/compose/material/samples/TextFieldSamples.kt;l=189?q=compose%20sample%20text%20input)
+ */
+internal val Icons.Filled.VisibilityOff: ImageVector
+    get() {
+        if (_visibilityOff != null) {
+            return _visibilityOff!!
+        }
+        _visibilityOff =
+            materialIcon(name = "Filled.VisibilityOff") {
+                materialPath {
+                    moveTo(12.0f, 7.0f)
+                    curveToRelative(2.76f, 0.0f, 5.0f, 2.24f, 5.0f, 5.0f)
+                    curveToRelative(0.0f, 0.65f, -0.13f, 1.26f, -0.36f, 1.83f)
+                    lineToRelative(2.92f, 2.92f)
+                    curveToRelative(1.51f, -1.26f, 2.7f, -2.89f, 3.43f, -4.75f)
+                    curveToRelative(-1.73f, -4.39f, -6.0f, -7.5f, -11.0f, -7.5f)
+                    curveToRelative(-1.4f, 0.0f, -2.74f, 0.25f, -3.98f, 0.7f)
+                    lineToRelative(2.16f, 2.16f)
+                    curveTo(10.74f, 7.13f, 11.35f, 7.0f, 12.0f, 7.0f)
+                    close()
+                    moveTo(2.0f, 4.27f)
+                    lineToRelative(2.28f, 2.28f)
+                    lineToRelative(0.46f, 0.46f)
+                    curveTo(3.08f, 8.3f, 1.78f, 10.02f, 1.0f, 12.0f)
+                    curveToRelative(1.73f, 4.39f, 6.0f, 7.5f, 11.0f, 7.5f)
+                    curveToRelative(1.55f, 0.0f, 3.03f, -0.3f, 4.38f, -0.84f)
+                    lineToRelative(0.42f, 0.42f)
+                    lineTo(19.73f, 22.0f)
+                    lineTo(21.0f, 20.73f)
+                    lineTo(3.27f, 3.0f)
+                    lineTo(2.0f, 4.27f)
+                    close()
+                    moveTo(7.53f, 9.8f)
+                    lineToRelative(1.55f, 1.55f)
+                    curveToRelative(-0.05f, 0.21f, -0.08f, 0.43f, -0.08f, 0.65f)
+                    curveToRelative(0.0f, 1.66f, 1.34f, 3.0f, 3.0f, 3.0f)
+                    curveToRelative(0.22f, 0.0f, 0.44f, -0.03f, 0.65f, -0.08f)
+                    lineToRelative(1.55f, 1.55f)
+                    curveToRelative(-0.67f, 0.33f, -1.41f, 0.53f, -2.2f, 0.53f)
+                    curveToRelative(-2.76f, 0.0f, -5.0f, -2.24f, -5.0f, -5.0f)
+                    curveToRelative(0.0f, -0.79f, 0.2f, -1.53f, 0.53f, -2.2f)
+                    close()
+                    moveTo(11.84f, 9.02f)
+                    lineToRelative(3.15f, 3.15f)
+                    lineToRelative(0.02f, -0.16f)
+                    curveToRelative(0.0f, -1.66f, -1.34f, -3.0f, -3.0f, -3.0f)
+                    lineToRelative(-0.17f, 0.01f)
+                    close()
+                }
+            }
+        return _visibilityOff!!
+    }
+private var _visibilityOff: ImageVector? = null

--- a/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/model/InputFieldError.kt
+++ b/composeApp/src/commonMain/kotlin/com/theseuntaylor/snippy/ui/model/InputFieldError.kt
@@ -1,0 +1,7 @@
+package com.theseuntaylor.snippy.ui.model
+
+data class InputFieldError(val shouldShowError: Boolean, val message: String) {
+    companion object {
+        val Initial = InputFieldError(shouldShowError = false, message = "")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ multiplatformSettings = "1.3.0"
 kermit = "2.0.5"
 androidx-room = "2.7.1"
 ksp = "2.1.20-1.0.31"
+androidx-navigation = "2.7.0-alpha07"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -40,6 +41,7 @@ androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-ui-android = { group = "androidx.compose.ui", name = "ui-android", version.ref = "uiAndroid" }
+androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }
 
 # Network - Ktor
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }


### PR DESCRIPTION
Kudos to @theseuntaylor, In this task, we added the following:

* Added Signup and Login flow.
* Added reusable core components such as `TextInput`, `TextInputField` and `PasswordTextInputField` amongst others.
* Navigation library for Jetpack Compose. 


https://github.com/user-attachments/assets/62185318-bf4f-4da2-9a50-7001228d5a33

https://github.com/user-attachments/assets/aef33fa3-999f-4270-968e-b317fc10564c


